### PR TITLE
Patch FirebaseSync to fix slow load times

### DIFF
--- a/FirebaseSync.js
+++ b/FirebaseSync.js
@@ -287,7 +287,6 @@ FirebaseSync.prototype.getRoomKeyOrMarkAsNonExistent = function() {
 
 		} else {
 
-			// TODO: Warn user if multiple rooms with same roomId.
 			this.roomKey = querySnapshot.key();
 			this.roomUrl = document.URL;
 			console.log("Got roomId from page URL " + document.URL);

--- a/JumpStart.js
+++ b/JumpStart.js
@@ -1311,7 +1311,7 @@ jumpStart.prototype.reallyFinishInit = function()
 
 		var myHandle = setInterval(function()
 		{
-			if( JumpStart.firebaseSync.roomKey === null )
+			if( !JumpStart.firebaseSync.roomKey )
 				return;
 
 			clearInterval(myHandle);


### PR DESCRIPTION
FirebaseSync would download data from all historical rooms for no good reason. This change uses Firebases's auto-generated key instead of a randomly generated integer, so that we don't have to download the entire set of rooms nor worry about duplicate rooms. As a side-effect, the roomId in the URL is now a unique Firebase key, e.g. "room-K8d64XfBfZawUoM45hv". 
